### PR TITLE
handle nested array-like features

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,14 @@
   }
 
   function feature(obj) {
-    return flatten(obj.geometry.coordinates);
+    switch (obj.geometry.type) {
+      case "GeometryCollection":
+        return geometryCollection(obj.geometry)
+      case "FeatureCollection":
+        return featureCollection(obj.geometry)
+      default:
+        return flatten(obj.geometry.coordinates)
+    }
   }
 
   function featureCollection(f) {

--- a/test/shapes.js
+++ b/test/shapes.js
@@ -149,7 +149,7 @@ exports.multilinestring = { "type": "MultiLineString",
       ]
     }
 
-exports.featureCollection = {
+const featureCollection = {
   "type": "FeatureCollection",
   "features": [
     {
@@ -268,8 +268,10 @@ exports.featureCollection = {
     }
   ]
 };
+exports.featureCollection = featureCollection
 
-exports.geometryCollection = { "type": "GeometryCollection",
+
+const geometryCollection = { "type": "GeometryCollection",
     "geometries": [
       { "type": "Point",
         "coordinates": [45.703125, 56.559482483762245]
@@ -300,6 +302,19 @@ exports.geometryCollection = { "type": "GeometryCollection",
       }
     ]
   };
+exports.geometryCollection = geometryCollection
+
+exports.nestedFeatureCollection = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": featureCollection
+}
+
+exports.nestedGeometryCollection = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": geometryCollection
+}
 
 //exports.baddy_nogeom = { type: "FeatureCollection", features: [ { type: "Feature", geometry: null, properties: {} } ] }
 exports.baddy_null = null;


### PR DESCRIPTION
We ran into an issue with features that had either feature collections or geometry collection geometries, which I believe are in geojson spec. Here's our fix for that if you're interested.