### PR TITLE
fix JavaScript engine's argument length limit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,19 +18,49 @@
   };
 
   function maxLat(coords) {
-    return Math.max.apply(null, coords.map(function(d) { return d[1]; }));
+    // fix JavaScript engine's argument length limit. 
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
+    let max = -Infinity;
+    let QUANTUM = 32768;
+    for (let i = 0, len = coords.length; i < len; i += QUANTUM) {
+        let sliceCoords = coords.slice(i, Math.min(i + QUANTUM, len));
+        let submax = Math.max.apply(null, sliceCoords.map(function (d) { return d[1]; }));
+        max = Math.max(submax, max);
+    }
+    return max;
   }
 
   function maxLng(coords) {
-    return Math.max.apply(null, coords.map(function(d) { return d[0]; }));
+    let max = -Infinity;
+    let QUANTUM = 32768;
+    for (let i = 0, len = coords.length; i < len; i += QUANTUM) {
+        let sliceCoords = coords.slice(i, Math.min(i + QUANTUM, len));
+        let submax = Math.max.apply(null, sliceCoords.map(function (d) { return d[0]; }));
+        max = Math.max(submax, max);
+    }
+    return max;
   }
 
   function minLat(coords) {
-    return Math.min.apply(null, coords.map(function(d) { return d[1]; }));
+    let min = Infinity;
+    let QUANTUM = 32768;
+    for (let i = 0, len = coords.length; i < len; i += QUANTUM) {
+        let sliceCoords = coords.slice(i, Math.min(i + QUANTUM, len));
+        let submin = Math.min.apply(null, sliceCoords.map(function (d) { return d[1]; }));
+        min = Math.min(submin, min);
+    }
+    return min;
   }
 
   function minLng(coords) {
-    return Math.min.apply(null, coords.map(function(d) { return d[0]; }));
+    let min = Infinity;
+    let QUANTUM = 32768;
+    for (let i = 0, len = coords.length; i < len; i += QUANTUM) {
+        let sliceCoords = coords.slice(i, Math.min(i + QUANTUM, len));
+        let submin = Math.min.apply(null, sliceCoords.map(function (d) { return d[0]; }));
+        min = Math.min(submin, min);
+    }
+    return min;
   }
 
   function fetchEnvelope(coords) {


### PR DESCRIPTION
fix #5. Actually, It's a JavaScript engine's argument length limit that causes the #5 issue.

From MDN: 
>But beware: by using apply this way, you run the risk of exceeding the JavaScript engine's argument length limit. The consequences of applying a function with too many arguments (that is, more than tens of thousands of arguments) varies across engines. (The JavaScriptCore engine has hard-coded argument limit of 65536.

> This is because the limit (and indeed, even the nature of any excessively-large-stack behavior) is unspecified. Some engines will throw an exception. More perniciously, others will arbitrarily limit the number of arguments actually passed to the applied function. To illustrate this latter case: if such an engine had a limit of four arguments (actual limits are of course significantly higher), it would be as if the arguments 5, 6, 2, 3 had been passed to apply in the examples above, rather than the full array.

reference: 
[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max)
[https://bugs.webkit.org/show_bug.cgi?id=80797](https://bugs.webkit.org/show_bug.cgi?id=80797)
[https://stackoverflow.com/a/56809779/6264535](https://stackoverflow.com/a/56809779/6264535)